### PR TITLE
Get away from master/slave language

### DIFF
--- a/code/training.py
+++ b/code/training.py
@@ -78,7 +78,7 @@ def estimate_betas(f_trainingset, trainingfeatures):
     ## estimating the beta parameters
     ## note: mirna_proximity is not considered in the fitting of betas
     f_beta_tmp = f_trainingset + '.parameters_beta.tmp'
-    os.system('R --slave --vanilla --args '+f_intermediate+' '+f_beta_tmp+\
+    os.system('R --subordinate --vanilla --args '+f_intermediate+' '+f_beta_tmp+\
               ' < external/choose_beta_params.R')
     betas = []
     with open(f_beta_tmp) as f:


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.